### PR TITLE
Fix: fix issues in sponsor updates

### DIFF
--- a/src/Pages/Attendance/AttendanceChart.tsx
+++ b/src/Pages/Attendance/AttendanceChart.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { AreaChart, Area, Tooltip, ResponsiveContainer } from "recharts";
 import { attendanceArrayRechart, graphColor } from "../../interfaces";
 import { customTooltip } from "./attendanceUtils";
@@ -7,7 +8,7 @@ type Props = {
   chartSeries: attendanceArrayRechart[];
 };
 
-const AttendanceChart = ({ chartOptions, chartSeries }: Props) => {
+const AttendanceChart = React.memo(({ chartOptions, chartSeries }: Props) => {
   return (
     <ResponsiveContainer width="100%" height="100%">
       <AreaChart
@@ -52,6 +53,6 @@ const AttendanceChart = ({ chartOptions, chartSeries }: Props) => {
       </AreaChart>
     </ResponsiveContainer>
   );
-};
+});
 
 export default AttendanceChart;

--- a/src/Pages/Sponsors/SponsorChart.tsx
+++ b/src/Pages/Sponsors/SponsorChart.tsx
@@ -1,6 +1,6 @@
 import { buildSponsorGraph, sponsorChartOptions } from "./sponsorsUtils";
 import Chart from "react-apexcharts";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   SponsorChartData,
   SponsorHistory,
@@ -11,30 +11,38 @@ import { useAuth } from "../../contexts/AuthContext";
 type Props = {
   values: SponsorHistory | undefined;
   retroActives: SponsorRetroactives;
+  refreshChart: boolean;
 };
-const SponsorChart = ({ values, retroActives }: Props) => {
-  const { isDarkMode } = useAuth();
-  const [chartLabels, setChartLabels] = useState<string[]>([]);
-  const [chartSeries, setChartSeries] = useState<SponsorChartData[]>([]);
+const SponsorChart = React.memo(
+  ({ values, retroActives, refreshChart }: Props) => {
+    const { isDarkMode } = useAuth();
+    const [chartLabels, setChartLabels] = useState<string[]>([]);
+    const [chartSeries, setChartSeries] = useState<SponsorChartData[]>([]);
 
-  useEffect(() => {
-    buildSponsorGraph(values, retroActives, setChartSeries, setChartLabels);
-  }, [values, retroActives]);
-  return (
-    <div>
-      <Chart
-        options={{
-          ...sponsorChartOptions,
-          theme: { mode: isDarkMode ? "dark" : "light" },
-          labels: chartLabels,
-        }}
-        series={chartSeries}
-        type={"bar"}
-        width="100%"
-        height="300"
-      />
-    </div>
-  );
-};
+    useEffect(() => {
+      buildSponsorGraph(
+        !!values ? values : {},
+        retroActives,
+        setChartSeries,
+        setChartLabels
+      );
+    }, [values, retroActives, refreshChart]);
+    return (
+      <div>
+        <Chart
+          options={{
+            ...sponsorChartOptions,
+            theme: { mode: isDarkMode ? "dark" : "light" },
+            labels: chartLabels,
+          }}
+          series={chartSeries}
+          type={"bar"}
+          width="100%"
+          height="300"
+        />
+      </div>
+    );
+  }
+);
 
 export default SponsorChart;

--- a/src/Pages/Sponsors/SponsorImage.tsx
+++ b/src/Pages/Sponsors/SponsorImage.tsx
@@ -13,6 +13,7 @@ const SponsorImage = ({ svgPath }: Props) => {
     getSvgStringFromPath(svgPath, setSvgString);
   }, [svgPath]);
 
+  if (!svgPath) return null;
   if (!svgString) return <Spinner size="large" type="arc" variant="brand" />;
 
   //   const jsxEl = parse(s) as JSX.Element;

--- a/src/Pages/Sponsors/SponsorModal.tsx
+++ b/src/Pages/Sponsors/SponsorModal.tsx
@@ -8,14 +8,9 @@ import SponsorFileIcon from "./icons/SponsorFileIcon";
 import SponsorChart from "./SponsorChart";
 import SponsorImage from "./SponsorImage";
 import {
-  addNewSeason,
-  deleteSeason,
   deleteSponsor,
   downloadSponsorFile,
-  editSeasonHandler,
-  editSeasonValueHandler,
   saveSponsor,
-  sponsorInputHandler,
   uploadSponsorSvgToServer,
 } from "./sponsorsUtils";
 import { useAuth } from "../../contexts/AuthContext";

--- a/src/Pages/Sponsors/SponsorModalAddSeason.tsx
+++ b/src/Pages/Sponsors/SponsorModalAddSeason.tsx
@@ -1,0 +1,114 @@
+import React, { Fragment, useState } from "react";
+import { Sponsor } from "../../interfaces";
+import NumberFormat from "react-number-format";
+import { useAuth } from "../../contexts/AuthContext";
+import {
+  addNewSeason,
+  deleteSeason,
+  editSeasonHandler,
+  editSeasonValueHandler,
+} from "./sponsorsUtils";
+
+type Props = {
+  sponsorInfo: Sponsor | null;
+  setSponsorInfo: Function;
+  setRefreshChart: Function;
+};
+
+const SponsorModalAddSeason = ({
+  sponsorInfo,
+  setSponsorInfo,
+  setRefreshChart,
+}: Props) => {
+  const { isMarketingOrAdmin } = useAuth();
+  const [focusInput, setFocusInput] = useState("");
+  return (
+    <Fragment>
+      <div className="row form-group text-center">
+        <div className="col-1"></div>
+        <div className="col-5 text-dark small text-uppercase">Season</div>
+        <div className="col-5 text-dark small text-uppercase">Value</div>
+        <div className="col-1"></div>
+        {sponsorInfo?.history &&
+          Object.entries(sponsorInfo?.history).map(([season, value]) => {
+            return (
+              <Fragment key={season}>
+                <div className="col-1"></div>
+                <div className="col-5">
+                  <NumberFormat
+                    value={season.replace("-", "/")}
+                    readOnly={isMarketingOrAdmin ? false : true}
+                    className="form-control text-center"
+                    format={"####/####"}
+                    allowEmptyFormatting
+                    mask="_"
+                    autoFocus={season === focusInput}
+                    onValueChange={(val) =>
+                      editSeasonHandler(
+                        val.formattedValue,
+                        season,
+                        sponsorInfo,
+                        setSponsorInfo,
+                        setFocusInput
+                      )
+                    }
+                  />
+                </div>
+                <div className="col-5">
+                  <NumberFormat
+                    value={value}
+                    readOnly={isMarketingOrAdmin ? false : true}
+                    onValueChange={(value) =>
+                      editSeasonValueHandler(
+                        value.floatValue ? value.floatValue : 0,
+                        season,
+                        sponsorInfo,
+                        setSponsorInfo
+                      )
+                    }
+                    decimalScale={2}
+                    fixedDecimalScale={true}
+                    suffix={" €"}
+                    thousandSeparator={" "}
+                    className="form-control text-center"
+                    placeholder="  €"
+                  />
+                </div>
+
+                <div className="col-1 justify-content-center d-flex align-items-center">
+                  {isMarketingOrAdmin && (
+                    <span
+                      className={"float-right cursor-pointer text-danger"}
+                      onClick={() => {
+                        deleteSeason(season, sponsorInfo, setSponsorInfo);
+                        setRefreshChart((state: boolean) => !state);
+                      }}
+                    >
+                      <i className="fa fa-times"></i>
+                    </span>
+                  )}
+                </div>
+              </Fragment>
+            );
+          })}
+      </div>
+
+      {isMarketingOrAdmin && (
+        <div className="row">
+          <div className="col-4"></div>
+          <div className="col d-flex justify-content-center">
+            <button
+              className="btn btn-outline-success"
+              onClick={() => addNewSeason(sponsorInfo, setSponsorInfo)}
+            >
+              Add Season
+            </button>
+          </div>
+          <div className="col-4"></div>
+        </div>
+      )}
+    </Fragment>
+  );
+};
+
+export default SponsorModalAddSeason;

--- a/src/Pages/Sponsors/SponsorModalInfo.tsx
+++ b/src/Pages/Sponsors/SponsorModalInfo.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { Fragment } from "react";
+import { useAuth } from "../../contexts/AuthContext";
+import { Sponsor } from "../../interfaces";
+import { sponsorInputHandler } from "./sponsorsUtils";
+import NumberFormat from "react-number-format";
+
+type Props = {
+  sponsorInfo: Sponsor | null;
+  setSponsorInfo: Function;
+};
+
+const SponsorModalInfo = ({ sponsorInfo, setSponsorInfo }: Props) => {
+  const { isMarketingOrAdmin } = useAuth();
+  let sponsorValue = 0;
+  if (sponsorInfo?.history) {
+    let vals = Object.entries(sponsorInfo.history).map(([_, val]) => val);
+    sponsorValue = vals[vals.length - 1];
+  }
+  return (
+    <Fragment>
+      <div className="form-group row text-center">
+        <div className="col">
+          <label>
+            <span className="text-dark small text-uppercase">
+              <i className="fas fa-quote-right"></i>
+              <strong> Name</strong>
+            </span>
+          </label>
+
+          <input
+            value={sponsorInfo ? sponsorInfo.name : ""}
+            readOnly={isMarketingOrAdmin ? false : true}
+            onChange={(e) =>
+              sponsorInputHandler(e.target.value, "name", setSponsorInfo)
+            }
+            type="text"
+            className="form-control m-0 text-center"
+            placeholder=""
+          />
+        </div>
+        <div className="col">
+          <label>
+            <span className="text-dark small text-uppercase">
+              <i className="fas fa-quote-right"></i>
+              <strong> Bracket</strong>
+            </span>
+          </label>
+
+          <input
+            value={sponsorInfo ? sponsorInfo.level : ""}
+            readOnly
+            type="text"
+            className="form-control m-0 text-center"
+            placeholder=""
+          />
+        </div>
+        <div className="col">
+          <label>
+            <span className="text-dark small text-uppercase">
+              <i className="fas fa-euro-sign"></i>
+              <strong> Value</strong>
+            </span>
+          </label>
+
+          <NumberFormat
+            value={sponsorValue}
+            readOnly
+            onValueChange={(value) =>
+              sponsorInputHandler(
+                value.floatValue ? value.floatValue : 0,
+                "value",
+                setSponsorInfo
+              )
+            }
+            decimalScale={2}
+            fixedDecimalScale={true}
+            suffix={" €"}
+            thousandSeparator={" "}
+            className="form-control text-center"
+            placeholder="  €"
+          />
+        </div>
+      </div>
+      <div className="form-group row text-center">
+        <div className="col">
+          <label>
+            <span className="text-dark small text-uppercase">
+              <i className="fas fa-link"></i>
+              <strong> Website</strong>
+            </span>
+          </label>
+
+          <input
+            value={sponsorInfo ? sponsorInfo.url : ""}
+            readOnly={isMarketingOrAdmin ? false : true}
+            onChange={(e) =>
+              sponsorInputHandler(e.target.value, "url", setSponsorInfo)
+            }
+            type="text"
+            className="form-control m-0 text-center"
+            placeholder=""
+          />
+        </div>
+      </div>
+    </Fragment>
+  );
+};
+
+export default SponsorModalInfo;

--- a/src/Pages/Sponsors/Sponsors.tsx
+++ b/src/Pages/Sponsors/Sponsors.tsx
@@ -118,7 +118,7 @@ const Sponsors = () => {
                   className="btn btn-primary"
                   onClick={() => {
                     setCreateModalOpen(true);
-                    setNewSponsorInfo(sponsorSkeleton);
+                    setNewSponsorInfo({ ...sponsorSkeleton });
                   }}
                 >
                   Create Sponsor

--- a/src/Pages/Sponsors/sponsorsUtils.tsx
+++ b/src/Pages/Sponsors/sponsorsUtils.tsx
@@ -1078,7 +1078,9 @@ const filterSponsors = (
     return;
   }
   const filteredSponsors = sponsors.filter(([sponsorId, sponsor]) => {
-    return sponsor.name.toLowerCase().includes(searchTerm.toLowerCase());
+    return normalizedString(sponsor.name)
+      .toLowerCase()
+      .includes(normalizedString(searchTerm).toLowerCase());
   });
   setInventorySponsors(filteredSponsors);
 };

--- a/src/Pages/Sponsors/sponsorsUtils.tsx
+++ b/src/Pages/Sponsors/sponsorsUtils.tsx
@@ -805,8 +805,8 @@ const getInventorySponsors = (
 
     // order by name
     const sortedSponsors = Object.entries(allSponsors).sort((a, b) => {
-      let sponsorNameA = a[1].name;
-      let sponsorNameB = b[1].name;
+      let sponsorNameA = normalizedString(a[1].name).toLowerCase();
+      let sponsorNameB = normalizedString(b[1].name).toLowerCase();
 
       if (sponsorNameA > sponsorNameB) return 1;
       if (sponsorNameA < sponsorNameB) return -1;

--- a/src/Pages/Sponsors/sponsorsUtils.tsx
+++ b/src/Pages/Sponsors/sponsorsUtils.tsx
@@ -243,34 +243,31 @@ const addSponsorToBracket = (
  */
 const removeSponsorFromBracket = (sponsorId: string, bracketId: string) => {
   // retrieve board items from bracket
-  get(
-    ref(
-      db,
-      `private/sponsors/brackets/${bracketId}/sponsorsBoardList/${sponsorId}`
-    )
-  ).then((snapshot) => {
-    const sponsorsList: string[] = snapshot.val();
-    // remove from list
-    const newSponsorsList = sponsorsList.filter((sponsor) => {
-      return sponsor !== sponsorId;
-    });
+  get(ref(db, `private/sponsors/brackets/${bracketId}/sponsorsBoardList`)).then(
+    (snapshot) => {
+      const sponsorsList: string[] = snapshot.val();
+      // remove from list
+      const newSponsorsList = sponsorsList.filter((sponsor) => {
+        return sponsor !== sponsorId;
+      });
 
-    // Update with new List
-    set(
-      ref(db, `private/sponsors/brackets/${bracketId}/sponsorsBoardList`),
-      newSponsorsList
-    );
+      // Update with new List
+      set(
+        ref(db, `private/sponsors/brackets/${bracketId}/sponsorsBoardList`),
+        newSponsorsList
+      );
 
-    // Remove sponsor from bracket sponsors
-    remove(
-      ref(
-        db,
-        `private/sponsors/brackets/${bracketId}/bracketSponsors/${sponsorId}`
-      )
-    );
-    // update sponsor in inventory with blank bracket name
-    set(ref(db, `private/sponsors/inventory/${sponsorId}/level`), "");
-  });
+      // Remove sponsor from bracket sponsors
+      remove(
+        ref(
+          db,
+          `private/sponsors/brackets/${bracketId}/bracketSponsors/${sponsorId}`
+        )
+      );
+      // update sponsor in inventory with blank bracket name
+      set(ref(db, `private/sponsors/inventory/${sponsorId}/level`), "");
+    }
+  );
 };
 
 /**


### PR DESCRIPTION
This PR addresses several issues with sponsor updates:
- Removing season, not updating chart
- Previous sponsor info, remained when creating a new one
- Remove spinner from sponsors card when no svg 
- Improved performance of sponsor modal by using `React.memo` in chart