### PR TITLE
fix: fixed recruitment table being opened

### DIFF
--- a/src/Pages/Recruitment/recruitmentUtils.tsx
+++ b/src/Pages/Recruitment/recruitmentUtils.tsx
@@ -193,7 +193,11 @@ const toggleRegistration = (
   activeRecruitment: string | boolean
 ) => {
   if (activeRecruitment) set(ref(db, "public/recruitment/activeTable"), false);
-  else set(ref(db, "public/recruitment/activeTable"), tablesList[0]);
+  else
+    set(
+      ref(db, "public/recruitment/activeTable"),
+      tablesList[tablesList.length - 1]
+    );
 };
 
 /**


### PR DESCRIPTION
This pr fixes the case where when opening the recruitment, the wrong table was being selected