### PR TITLE
feat: adds to buy badge to budget

### DIFF
--- a/src/Pages/Budget/badgeBomRender.tsx
+++ b/src/Pages/Budget/badgeBomRender.tsx
@@ -13,6 +13,8 @@ const BadgeBomRender = (props: ICellRendererParams) => {
     <span className="badge badge-pill badge-warning">In Progress</span>
   ) : cellValue === "Sponsor" ? (
     <span className="badge badge-pill badge-info">Sponsor</span>
+  ) : cellValue === "To Buy" ? (
+    <span className="badge badge-pill badge-orange">To Buy</span>
   ) : (
     <span>"Format error"</span>
   );

--- a/src/Pages/Budget/budgetUtils.tsx
+++ b/src/Pages/Budget/budgetUtils.tsx
@@ -755,6 +755,7 @@ const statusSelectOptions = [
   { value: "In Progress", label: "In Progress" },
   { value: "Acquired", label: "Acquired" },
   { value: "Sponsor", label: "Sponsor" },
+  { value: "To Buy", label: "To Buy" },
 ];
 
 interface depSelectOptions {

--- a/src/Pages/Dashboard/dashboardUtils.tsx
+++ b/src/Pages/Dashboard/dashboardUtils.tsx
@@ -228,6 +228,7 @@ const getMaterialStatusBadge = (toDo: taskShape & BomMaterial) => {
     else if (toDo.status === "In Progress")
       colors = ["bg-warning", "badge-warning"];
     else if (toDo.status === "Sponsor") colors = ["bg-info", "badge-info"];
+    else if (toDo.status === "To Buy") colors = ["bg-orange", "badge-orange"];
   }
   return colors;
 };
@@ -342,7 +343,8 @@ const getUserBomMaterials = (user: userContext | null) => {
       Object.entries(materials).forEach(([key, material]) => {
         if (
           material.status === "Required" ||
-          material.status === "In Progress"
+          material.status === "In Progress" ||
+          material.status === "To Buy"
         ) {
           todoMaterials[key] = material;
         }

--- a/src/assets/scss/colors.scss
+++ b/src/assets/scss/colors.scss
@@ -3,6 +3,7 @@ $primary-color: #3f6ad8;
 $success-color: #3ac47d;
 $warning-color: #f7b924;
 $danger-color: #d92550;
+$orange-color: #ff5733;
 
 $white-primary: #fff;
 $white-secondary: #fafbfc;

--- a/src/assets/scss/customBootstrap.scss
+++ b/src/assets/scss/customBootstrap.scss
@@ -341,6 +341,24 @@ button.bg-danger {
   }
 }
 
+.bg-orange {
+  background-color: $orange-color !important;
+}
+
+a.bg-orange {
+  &:hover,
+  &:focus {
+    background-color: darken($orange-color, 20%);
+  }
+}
+
+button.bg-orange {
+  &:hover,
+  &:focus {
+    background-color: darken($orange-color, 20%);
+  }
+}
+
 .bg-light {
   background-color: #eee !important;
 }
@@ -17350,6 +17368,19 @@ a.badge-info {
   &:focus {
     color: #fff;
     background-color: #0090e2;
+  }
+}
+
+.badge-orange {
+  color: #fff;
+  background-color: $orange-color;
+}
+
+a.badge-orange {
+  &:hover,
+  &:focus {
+    color: #fff;
+    background-color: #D32F0C;
   }
 }
 


### PR DESCRIPTION
This PR adds a new status option to Budget page. The "To Buy"

<img width="1052" alt="image" src="https://user-images.githubusercontent.com/25829189/159827907-962683b1-2110-4ff0-b5ab-95419e395de7.png">
